### PR TITLE
use a single blob service

### DIFF
--- a/studio-server/pom.xml
+++ b/studio-server/pom.xml
@@ -67,14 +67,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-      <version>2.1.2</version>
+      <groupId>com.coremedia.cms</groupId>
+      <artifactId>cap-unified-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.coremedia.cms</groupId>
-      <artifactId>cap-unified-api</artifactId>
+      <artifactId>common.beans-for-plugins-container</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -88,6 +87,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryConfiguration.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryConfiguration.java
@@ -1,19 +1,37 @@
 package com.coremedia.labs.plugins.adapters.cloudinary;
 
+import com.coremedia.cap.common.BlobService;
+import com.coremedia.cap.common.CapConnection;
+import com.coremedia.cms.common.plugins.beans_for_plugins_container.CommonBeansForPluginsContainer;
 import com.coremedia.contenthub.api.BaseFileSystemConfiguration;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
 import com.coremedia.contenthub.api.ContentHubMimeTypeService;
 import com.coremedia.contenthub.api.ContentHubType;
+import com.coremedia.cotopaxi.common.blobs.BlobServiceImpl;
+import com.coremedia.mimetype.MimeTypeService;
+import com.coremedia.util.TempFileFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import java.util.Map;
 
+import static java.lang.invoke.MethodHandles.lookup;
+
 @Configuration
 @Import({BaseFileSystemConfiguration.class})
-public class CloudinaryConfiguration {
+public class CloudinaryConfiguration implements DisposableBean {
+
+  private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
+
+  @Nullable
+  private TempFileFactory tempFileFactory;
 
   private static Map<ContentHubType, String> typeMapping() {
     return Map.of(
@@ -30,7 +48,31 @@ public class CloudinaryConfiguration {
   }
 
   @Bean
-  public ContentHubAdapterFactory<?> cloudinaryContentHubAdapterFactory(@NonNull ContentHubMimeTypeService mimeTypeService) {
-    return new CloudinaryContentHubAdapterFactory(mimeTypeService, typeMapping());
+  public ContentHubAdapterFactory<?> cloudinaryContentHubAdapterFactory(@NonNull ContentHubMimeTypeService mimeTypeService,
+                                                                        BlobService blobService) {
+    return new CloudinaryContentHubAdapterFactory(mimeTypeService, blobService, typeMapping());
+  }
+
+  @Bean
+  public BlobService contentHubMimeTypeService(ObjectProvider<CommonBeansForPluginsContainer> commonBeansForPluginsContainer,
+                                               MimeTypeService mimeTypeService) {
+    return commonBeansForPluginsContainer.stream()
+            .map(CommonBeansForPluginsContainer::getConnection)
+            .map(CapConnection::getBlobService)
+            .findFirst()
+            .orElseGet(() -> createBlobService(mimeTypeService));
+  }
+
+  private BlobService createBlobService(MimeTypeService mimeTypeService) {
+    LOG.warn("Creating fallback BlobService for Cloudinary adapter because CapConnection is not available. Please check your plugin configuration.");
+    tempFileFactory = new TempFileFactory();
+    return new BlobServiceImpl(tempFileFactory, mimeTypeService);
+  }
+
+  @Override
+  public void destroy() {
+    if (tempFileFactory != null) {
+      tempFileFactory.destroy();
+    }
   }
 }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubAdapter.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubAdapter.java
@@ -2,6 +2,7 @@ package com.coremedia.labs.plugins.adapters.cloudinary;
 
 import com.cloudinary.Cloudinary;
 import com.cloudinary.utils.ObjectUtils;
+import com.coremedia.cap.common.BlobService;
 import com.coremedia.contenthub.api.*;
 import com.coremedia.contenthub.api.exception.ContentHubException;
 import com.coremedia.contenthub.api.pagination.PaginationRequest;
@@ -22,20 +23,25 @@ import java.util.stream.Collectors;
 
 class CloudinaryContentHubAdapter implements ContentHubAdapter {
   private static final Logger LOG = LoggerFactory.getLogger(CloudinaryContentHubTransformer.class);
+
   private final CloudinaryContentHubSettings settings;
-  private final CloudinaryOptions cloudinaryOptions;
   private final String connectionId;
-  private final CloudinaryService cloudinaryService;
   private final ContentHubMimeTypeService mimeTypeService;
+  private final BlobService blobService;
   private final Map<ContentHubType, String> itemTypeToContentTypeMapping;
+
+  private final CloudinaryOptions cloudinaryOptions;
+  private final CloudinaryService cloudinaryService;
 
   CloudinaryContentHubAdapter(@NonNull CloudinaryContentHubSettings settings,
                               @NonNull String connectionId,
                               @NonNull ContentHubMimeTypeService mimeTypeService,
+                              @NonNull BlobService blobService,
                               @NonNull Map<ContentHubType, String> itemTypeToContentTypeMapping) {
     this.settings = settings;
     this.connectionId = connectionId;
     this.mimeTypeService = mimeTypeService;
+    this.blobService = blobService;
     this.itemTypeToContentTypeMapping = itemTypeToContentTypeMapping;
 
     String apiKey = settings.getApiKey();
@@ -163,9 +169,8 @@ class CloudinaryContentHubAdapter implements ContentHubAdapter {
   @Override
   @NonNull
   public ContentHubTransformer transformer() {
-    return new CloudinaryContentHubTransformer(cloudinaryOptions);
+    return new CloudinaryContentHubTransformer(cloudinaryOptions, blobService, mimeTypeService);
   }
-
 
   private List<ContentHubObject> getRootFolders(ContentHubContext context) {
     CloudinaryFolder rootFolder = (CloudinaryFolder) getRootFolder(context);

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubAdapterFactory.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubAdapterFactory.java
@@ -1,5 +1,6 @@
 package com.coremedia.labs.plugins.adapters.cloudinary;
 
+import com.coremedia.cap.common.BlobService;
 import com.coremedia.contenthub.api.ContentHubAdapter;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
 import com.coremedia.contenthub.api.ContentHubMimeTypeService;
@@ -13,12 +14,15 @@ import java.util.Map;
  */
 class CloudinaryContentHubAdapterFactory implements ContentHubAdapterFactory<CloudinaryContentHubSettings> {
 
-  ContentHubMimeTypeService mimeTypeService;
+  private final ContentHubMimeTypeService mimeTypeService;
+  private final BlobService blobService;
   private final Map<ContentHubType, String> typeMapping;
 
   public CloudinaryContentHubAdapterFactory(ContentHubMimeTypeService mimeTypeService,
+                                            BlobService blobService,
                                             Map<ContentHubType, String> typeMapping) {
     this.mimeTypeService = mimeTypeService;
+    this.blobService = blobService;
     this.typeMapping = typeMapping;
   }
 
@@ -32,7 +36,7 @@ class CloudinaryContentHubAdapterFactory implements ContentHubAdapterFactory<Clo
   @Override
   public ContentHubAdapter createAdapter(@NonNull CloudinaryContentHubSettings settings,
                                          @NonNull String connectionId) {
-    return new CloudinaryContentHubAdapter(settings, connectionId, mimeTypeService, typeMapping);
+    return new CloudinaryContentHubAdapter(settings, connectionId, mimeTypeService, blobService, typeMapping);
   }
 
 }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubTransformer.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/cloudinary/CloudinaryContentHubTransformer.java
@@ -1,29 +1,32 @@
 package com.coremedia.labs.plugins.adapters.cloudinary;
 
 import com.coremedia.cap.common.Blob;
+import com.coremedia.cap.common.BlobService;
 import com.coremedia.contenthub.api.*;
-import com.coremedia.cotopaxi.common.blobs.BlobServiceImpl;
-import com.coremedia.mimetype.TikaMimeTypeService;
-import com.coremedia.util.TempFileFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.activation.MimeTypeParseException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 class CloudinaryContentHubTransformer implements ContentHubTransformer {
   private static final Logger LOG = LoggerFactory.getLogger(CloudinaryContentHubTransformer.class);
 
   private final CloudinaryOptions cloudinaryOptions;
+  private final BlobService blobService;
+  private final ContentHubMimeTypeService mimeTypeService;
 
-  private TikaMimeTypeService tikaMimeTypeService;
-
-  public CloudinaryContentHubTransformer(@NonNull CloudinaryOptions cloudinaryOptions) {
+  public CloudinaryContentHubTransformer(@NonNull CloudinaryOptions cloudinaryOptions,
+                                         @NonNull BlobService blobService,
+                                         @NonNull ContentHubMimeTypeService mimeTypeService) {
     this.cloudinaryOptions = cloudinaryOptions;
+    this.blobService = blobService;
+    this.mimeTypeService = mimeTypeService;
   }
 
   @Override
@@ -88,8 +91,7 @@ class CloudinaryContentHubTransformer implements ContentHubTransformer {
       // check if we are importing the blob
       if (!type.equals("CMVideo") || cloudinaryOptions.isImportVideoBlob()) {
         InputStream stream = item.stream(true);
-        BlobServiceImpl blobService = new BlobServiceImpl(new TempFileFactory(), getTika());
-        Blob blob = blobService.fromInputStream(stream, getTika().getMimeTypeForResourceName(item.getName() + "." + item.getFormat()));
+        Blob blob = blobService.fromInputStream(stream, mimeTypeService.mimeTypeForResourceName(item.getName() + "." + item.getFormat()));
         result.put("data", blob);
         if (stream != null) {
           stream.close();
@@ -100,17 +102,10 @@ class CloudinaryContentHubTransformer implements ContentHubTransformer {
         result.put("dataUrl", item.getAsset().getSecureUrl());
       }
       return result;
-    } catch (IOException | MimeTypeParseException e) {
+    } catch (IOException | IllegalArgumentException e) {
       LOG.error("Failed to determine media properties", e);
     }
     return null;
   }
 
-  private TikaMimeTypeService getTika() {
-    if (tikaMimeTypeService == null) {
-      this.tikaMimeTypeService = new TikaMimeTypeService();
-      tikaMimeTypeService.init();
-    }
-    return tikaMimeTypeService;
-  }
 }


### PR DESCRIPTION
avoid memory leak due to cleanup thread started by each TempFileFactory instance

it would be preferable to use com.coremedia.cms.common.plugins.beans_for_plugins2.CommonBeansForPluginsConfiguration and not to create a fallback blob service, but that's currently prevented by `com.coremedia.contenthub.api.BaseFileSystemConfiguration` (see https://coremediagmbh.atlassian.net/browse/CMS-25756). This temporary fix relies on the private API dependency `com.coremedia.cms.common.plugins.beans_for_plugins_container.CommonBeansForPluginsContainer`

Found this while working on https://coremedia.zendesk.com/agent/tickets/87572 and looking at https://coremedia.zendesk.com/agent/tickets/79089

The very same problem exists in other content hub adapter implementations as well:

- https://github.com/CoreMedia/content-hub-adapter-dropbox/blob/495a5e21df3a95317c68ef1de10ecd34987260a8/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/DropboxContentHubTransformer.java#L104
- https://github.com/CoreMedia/content-hub-adapter-filesystem/blob/b455bee3e066ebea090b30f7f573800c42da4b74/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/filesystem/server/FilesystemContentHubTransformer.java#L86

Note: I didn't test this fix, but it's definitely not a good idea to create temporary TempFileFactory instances.